### PR TITLE
Allow DelaySeconds to be specified in SubmitTaskInput

### DIFF
--- a/src/__tests__/noop-client.test.ts
+++ b/src/__tests__/noop-client.test.ts
@@ -55,6 +55,14 @@ describe('NoopClient', () => {
       })
       await expect(response).rejects.toThrowError('Payload validation failed')
     })
+
+    it('throws a TypeError if a delaySeconds of >900 is provided', async () => {
+      const response = client.submitTask({
+        ...exampleTaskRequest,
+        delaySeconds: 901
+      })
+      await expect(response).rejects.toThrowError(/DelaySeconds too large/)
+    })
   })
 
   describe('submitAllTasks', () => {
@@ -71,6 +79,7 @@ describe('NoopClient', () => {
       expect(results[0].status).toEqual(BatchSubmitTaskStatus.SUCCESSFUL)
       expect(results[0].error).toEqual(undefined)
     })
+
     it('throws the exception if validation of any task fails', async () => {
       const invalidTaskRequest = {
         ...exampleTaskRequest,
@@ -82,6 +91,16 @@ describe('NoopClient', () => {
       const promise = client.submitAllTasks([exampleTaskRequest, invalidTaskRequest])
 
       await expect(promise).rejects.toThrowError()
+    })
+
+    it('throws a TypeError if a delaySeconds of >900 is provided', async () => {
+      const response = client.submitAllTasks([
+        {
+          ...exampleTaskRequest,
+          delaySeconds: 901
+        }
+      ])
+      await expect(response).rejects.toThrowError(/DelaySeconds too large/)
     })
   })
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,6 +10,15 @@ export interface GetConsumersInput<TContext = DefaultTaskContext> {
 export interface SubmitTaskInput<T> {
   operationName: string
   payload: T
+
+  /**
+   * Number of seconds to wait before making the message visible. Defaults to 0
+   *
+   * Max allowed value by SQS is 900 (15 minutes)
+   *
+   * More Info: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html
+   */
+  delaySeconds?: number
 }
 
 export interface SubmitTaskResponse {


### PR DESCRIPTION
SQS does provide the ability to delay visibility of a message by up to 15 minutes[1]. This change exposes this capability with an optional delaySeconds argument in payloads for both submitTask and submitAllTasks.

* add delaySeconds?: number to SubmitTaskInput
* map delaySeconds to DelaySeconds in calls in SQS Client
* provide a sanity check for delaySeconds in NoopClient

[1] https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html