### PR TITLE
feat: add client.generateConsumer

### DIFF
--- a/src/__tests__/noop-client.test.ts
+++ b/src/__tests__/noop-client.test.ts
@@ -1,3 +1,4 @@
+import { Consumer } from 'sqs-consumer'
 import { NoopClient } from '../noop-client'
 import { handleFunction, validationFunction, validPayload } from './test-util'
 import { OperationConfiguration } from '../types'
@@ -101,6 +102,13 @@ describe('NoopClient', () => {
         }
       ])
       await expect(response).rejects.toThrowError(/DelaySeconds too large/)
+    })
+  })
+
+  describe('generateConsumer', () => {
+    it('returns a defunct Consumer', () => {
+      const consumer = client.generateConsumer()
+      expect(consumer).toBeInstanceOf(Consumer)
     })
   })
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,6 +7,11 @@ export interface GetConsumersInput<TContext = DefaultTaskContext> {
   consumerOpts?: ConsumerOptions
 }
 
+export interface GetConsumerInput<TContext = DefaultTaskContext>
+  extends GetConsumersInput<TContext> {
+  queueName: string
+}
+
 export interface SubmitTaskInput<T> {
   operationName: string
   payload: T
@@ -96,5 +101,6 @@ export interface TaskClient<TContext> {
     input: SubmitTaskInput<TPayload>[]
   ): Promise<SubmitAllTasksResponse>
 
+  generateConsumer(input: GetConsumerInput<TContext>): Consumer
   generateConsumers(input: GetConsumersInput<TContext>): Record<QueueName, Consumer>
 }

--- a/src/noop-client.ts
+++ b/src/noop-client.ts
@@ -52,6 +52,15 @@ export class NoopClient<TContext = DefaultTaskContext> implements TaskClient<TCo
     return { results }
   }
 
+  public generateConsumer(): Consumer {
+    return new Consumer({
+      queueUrl: 'http://localhost/no-op-client',
+      handleMessage: async (): Promise<void> => {
+        'handleMessage'
+      }
+    })
+  }
+
   public generateConsumers(): Record<QueueName, Consumer> {
     return {}
   }


### PR DESCRIPTION
* feat: add client.queueNames to retrieve a list of configured queues
* add generateConsumer to TaskClient interface
* implement generateConsumer on SQSClient
* implement generateConsumer on NoopClient
* minor: change SQSClient.generateConsumers to call client.generateConsumer